### PR TITLE
Add full $PATH, better terminal choice, and automatic graphical/terminal detection

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,8 +6,14 @@
     chrome)
   - Open a website normally (in a new tab)
 ** How does it work?
-   - For graphical apps: lists apps found in =/bin=
-   - For cli apps: lists apps named in =~/.dmenu-terminal= (whitespace delimited)
+   - Lists apps found in =$PATH=
+   - Attempts to guess whether graphical or terminal. If it makes a mistake, you can (make and) add an entry to =~/.dmenu-terminal=. Format:
+     #+BEGIN_SRC
+     app_name [0 for terminal, 1  for graphical]
+     app_two 0
+     app_three 1
+     Lines that don't contain an app name are ignored
+     #+END_SRC
    - For websites: lists sites named in =~/.dmenu-web=. Format:
      #+BEGIN_SRC
      # comments start with a # sign at the start of a line

--- a/dmenu-custom
+++ b/dmenu-custom
@@ -128,21 +128,25 @@ if [ -e "$terminalProgramsList" ]; then
   # chop the choice up so you can pass arguments via dmenu
   # (e.g. mutt -R to open a mutt (mail program) in read-only mode)
   firstWordOfChoice="$(echo "$choice" | cut -d" " -f1)"
+  override=$(grep "$terminalProgramsList" -e $firstWordOfChoice)
+fi
 
-  terminalProgram="$(
-    grep -v "^#" "$terminalProgramsList" | \
-    tr -sc "[:alpha:]" "\n"              | \
-    grep "$firstWordOfChoice"            | \
-    tr -d "[:blank:]"
-  )"
-
-  if [ -n "$terminalProgram" ]; then
-    # allow word-splitting so arguments can be passed to programs
-    # shellcheck disable=SC2086
-    exec $terminal -e $choice
+# isxapp is 0 if console, 1 if graphical
+if [ -n "$override" ]; then
+  isxapp=$(echo "$override" | cut -d" " -f2)
+else
+  fullpath=$(command -v "$firstWordOfChoice")
+  # query ldd to guess if graphical if not otherwise defined
+  if [ -n "$(ldd "$fullpath" | grep libX11)" ]; then
+    isxapp="1"
+  else
+    isxapp="0"
   fi
 fi
 
-# allow word-splitting so arguments can be passed to programs
-# shellcheck disable=SC2086
-exec $choice
+if [ "0" != "$isxapp" ]; then
+  exec $choice
+else
+  exec $terminal -e $choice
+fi
+

--- a/dmenu-custom
+++ b/dmenu-custom
@@ -37,6 +37,29 @@ _get_launchable_programs() {
   fi
 }
 
+_first_exists() {
+  for i in "$@"; do
+    if [ -x "$(command -v -- $i)" ]; then
+      echo "$i"
+      break
+    fi
+  done
+}
+
+
+if [ "$#" -ne 1 -a -x "$(command -v -- "$1")" ]; then
+  terminal="$1"
+  shift
+else
+  terminal=$(_first_exists \
+    "$TERMINAL" \
+    "i3-sensible-terminal" \
+    "x-terminal-emulator" \
+    "urxvt" \
+    "xterm"
+  )
+fi
+
 # prompt the user to choose a site/program/program alias, showing the most recently launched first
 choice="$(printf "%s\n%s" "$(_get_launchable_websites)" "$(_get_launchable_programs)" | sort | uniq \
           | cat - "$launchHistory" "$launchHistory" | sort | uniq -u | cat "$launchHistory" - \
@@ -116,7 +139,7 @@ if [ -e "$terminalProgramsList" ]; then
   if [ -n "$terminalProgram" ]; then
     # allow word-splitting so arguments can be passed to programs
     # shellcheck disable=SC2086
-    exec urxvt -e $choice
+    exec $terminal -e $choice
   fi
 fi
 

--- a/dmenu-custom
+++ b/dmenu-custom
@@ -47,7 +47,7 @@ _first_exists() {
 }
 
 
-if [ "$#" -ne 1 -a -x "$(command -v -- "$1")" ]; then
+if [ "$#" -ge 1 -a -x "$(command -v -- "$1")" ]; then
   terminal="$1"
   shift
 else

--- a/dmenu-custom
+++ b/dmenu-custom
@@ -30,7 +30,11 @@ _get_launchable_websites() {
 }
 
 _get_launchable_programs() {
-  ls /bin
+  if [ -x "$(command -v dmenu_path)" ]; then
+    dmenu_path
+  else
+    ls /usr/bin
+  fi
 }
 
 # prompt the user to choose a site/program/program alias, showing the most recently launched first


### PR DESCRIPTION
Basically just a translation of [my dmenu-terminal pull request](https://github.com/losingkeys/dmenu-terminal/pull/2) to here, per request, as well as fixes given in the review there. I can also add my [proposed addition to the dmenu-web part](https://github.com/losingkeys/dmenu-custom/issues/2) here, but because it's so different from my previous PR I figured I'd ask first.

- Uses `dmenu_path` to enumerate the full path rather than just `/bin`
- Adds a whole order of terminal preference (argument, system spec, urxvt, xterm)
- Automatic graphical or terminal detection
  - Changes ~/.dmenu-terminal format to an override, included in README.